### PR TITLE
Follow PEP-0394 shebang style

### DIFF
--- a/adb-sync
+++ b/adb-sync
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Copyright 2014 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
Python script that use version-specific syntax (either 2 or 3) should specify shebang accordingly. This makes  python system version switching easier.