### PR TITLE
adb-sync: Allow syncing symlinks

### DIFF
--- a/adb-sync
+++ b/adb-sync
@@ -324,7 +324,7 @@ def BuildFileList(fs, path, prefix=b''):
     for n in files:
       for t in BuildFileList(fs, path + b'/' + n, prefix + b'/' + n):
         yield t
-  elif stat.S_ISREG(statresult.st_mode):
+  elif stat.S_ISREG(statresult.st_mode) or stat.S_ISLNK(statresult.st_mode):
     yield prefix, statresult
   else:
     _print(b'Note: unsupported file: %s', path)


### PR DESCRIPTION
It is artificial limitation and actually works with adb (though it
might not work with absolute links, same as with rsync)
