### PR TITLE
Issue #11: adb-channel fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,20 +98,20 @@ convenience wrapper to connect a networking socket on the Android device to
 file descriptors on the PC side. It can even launch and shut down the given
 application automatically!
 
-It is best used as a `ProxyCommand` for SSH (intall
+It is best used as a `ProxyCommand` for SSH (install
 [SSHelper](https://play.google.com/store/apps/details?id=com.arachnoid.sshelper)
 first) using a configuration like:
 
 ```
-Host sshhelper
+Host sshelper
 Port 2222
 ProxyCommand adb-channel tcp:%p com.arachnoid.sshelper/.SSHelperActivity 1
 ```
 
-After adding this to `~/.ssh/config`, run `ssh-copy-id sshhelper`.
+After adding this to `~/.ssh/config`, run `ssh-copy-id sshelper`.
 
 Congratulations! You can now use `rsync`, `sshfs` etc. to the host name
-`sshhelper`.
+`sshelper`.
 
 Contributing
 ============

--- a/adb-channel
+++ b/adb-channel
@@ -16,7 +16,7 @@ atexit() {
 trap atexit EXIT
 trap 'exit 0' HUP INT ALRM TERM
 
-[ -z "${activity}" ] || adb shell am start -W ${activity}
+[ -z "${activity}" ] || adb shell -n am start -W ${activity}
 [ -z "${delay}" ] || sleep "${delay}"
 adb forward localfilesystem:"${t}/sock" "${remote}"
 socat stdio unix:"${t}/sock"


### PR DESCRIPTION
`ProxyCommand` failed on Mac unless `adb shell` invoked with `-n` (don't read from stdin). I did not test on Linux but I assume this would not cause problems there.