### PR TITLE
Respect users $PATH settings

### DIFF
--- a/adb-sync
+++ b/adb-sync
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright 2014 Google Inc. All rights reserved.
 #


### PR DESCRIPTION
Using `#!/usr/bin/python3` assumes that users have python installed into `/usr/bin/`.  
Many users use `pyenv` or something similar to set up their python interpreter. 

This PR makes `adb-sync` more robust in these cases.