### PR TITLE
Fix --times with current Android toolbox

### DIFF
--- a/adb-sync
+++ b/adb-sync
@@ -303,14 +303,14 @@ class AdbFileSystem(GlobLike, OSLike):
     # TODO(rpolzer): Find out why this does not work (returns status 255).
     """Set the time of a file to a specified unix time."""
     atime, mtime = times
-    timestr = time.strftime('%Y%m%d.%H%M%S',
+    timestr = time.strftime('%Y%m%d%H%M.%S',
                             time.localtime(mtime)).encode('ascii')
     if subprocess.call(
         self.adb +
         [b'shell',
          b'touch -mt %s %s' % (timestr, self.QuoteArgument(path))]) != 0:
       raise OSError('touch failed')
-    timestr = time.strftime('%Y%m%d.%H%M%S',
+    timestr = time.strftime('%Y%m%d%H%M.%S',
                             time.localtime(atime)).encode('ascii')
     if subprocess.call(
         self.adb +


### PR DESCRIPTION
When trying to use --times to push files back to a device it fails with the error:
```
touch: bad '20190519.083235'
INFO:root:Total: 23412 KB/s (1256329659 bytes in 52.402s)
Traceback (most recent call last):
  File "./adb-sync", line 883, in <module>
    main()
  File "./adb-sync", line 877, in main
    syncer.PerformCopies()
  File "./adb-sync", line 646, in PerformCopies
    self.dst_fs[i].utime(dst_name, (s.st_atime, s.st_mtime))
  File "./adb-sync", line 312, in utime
    raise OSError('touch failed')
OSError: touch failed
```
because of the current versions of toolbox used on Android devices. So this change fixes the format.