### PR TITLE
Fix: weird char sequence throwing java error

### DIFF
--- a/adb-channel
+++ b/adb-channel
@@ -9,7 +9,7 @@ activity=${2}
 delay=${3}
 
 atexit() {
-  [ -z "${activity}" ] || adb shell am force-stop ${activity%%/*}
+  [ -z "${activity}" ] || adb shell am force-stop ${activity}
   adb forward --remove localfilesystem:"${t}/sock"
   rm -rf "${t}"
 }


### PR DESCRIPTION
I guess it's just a mistake... 
Got this java error after exciting the ssh login:

```
Exception occurred while executing 'force-stop':
java.lang.IllegalArgumentException: Argument expected after "force-stop"
	at com.android.modules.utils.BasicShellCommandHandler.getNextArgRequired(BasicShellCommandHandler.java:295)
	at com.android.server.am.ActivityManagerShellCommand.runForceStop(ActivityManagerShellCommand.java:1138)
	at com.android.server.am.ActivityManagerShellCommand.onCommand(ActivityManagerShellCommand.java:239)
	at com.android.modules.utils.BasicShellCommandHandler.exec(BasicShellCommandHandler.java:97)
	at android.os.ShellCommand.exec(ShellCommand.java:38)
	at com.android.server.am.ActivityManagerService.onShellCommand(ActivityManagerService.java:10429)
	at android.os.Binder.shellCommand(Binder.java:986)
	at android.os.Binder.onTransact(Binder.java:860)
	at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:6049)
	at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:3034)
	at android.os.Binder.execTransactInternal(Binder.java:1220)
	at android.os.Binder.execTransact(Binder.java:1179)
```