### PR TITLE
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc0 in position 0: invalid start byte

### DIFF
--- a/adb-sync
+++ b/adb-sync
@@ -212,7 +212,7 @@ class AdbFileSystem(GlobLike, OSLike):
     # while echo does its own backslash escape handling additionally to the
     # shell's. Too bad printf "%s\n" is not available.
     test_strings = [
-        b'(', b'(;  #`ls`$PATH\'"(\\\\\\\\){};!\xc0\xaf\xff\xc2\xbf'
+        b'(', b'(;  #`ls`$PATH\'"(\\\\\\\\){};!'
     ]
     for test_string in test_strings:
       good = False


### PR DESCRIPTION
https://github.com/google/adb-sync/issues/41